### PR TITLE
devモード時におけるフッターのリンクを修正

### DIFF
--- a/components/DevelopmentModeMark.vue
+++ b/components/DevelopmentModeMark.vue
@@ -2,7 +2,7 @@
   <div v-if="isDevelopmentMode" class="DevelopmentModeMark">
     開発中（development mode）
     <a
-      href="https://stopcovid19.metro.tokyo.lg.jp/"
+      href="https://covid19.codeforaomori.org/"
       target="_blank"
       rel="noopener"
     >


### PR DESCRIPTION
issue立てられないので直PRになります、すみません🙇‍♂️

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- devモードで表示される`DevelopmentModeMark.vue`内の公開サイトへのURLがhttps://stopcovid19.metro.tokyo.lg.jp/ であった為、https://covid19.codeforaomori.org/ に修正
